### PR TITLE
fix(sonar): exclude main.ts from coverage reporting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["bazel", "lgorniak", "libpeerconnection", "scannerwork", "sonarcloud", "testem"]
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.exclusions=**/node_modules/**,**/*.spec.ts,src/test.ts,src/environments/*
 # Coverage reporting
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
-sonar.coverage.exclusions=**/*.spec.ts,src/test.ts,src/environments/*
+sonar.coverage.exclusions=**/*.spec.ts,src/test.ts,src/environments/*,src/main.ts
 
 # TypeScript configuration
 sonar.typescript.tsconfigPath=tsconfig.json 


### PR DESCRIPTION
This PR excludes main.ts from SonarCloud coverage reporting as it is infrastructure code. Added main.ts to sonar.coverage.exclusions in sonar-project.properties. This follows Angular best practices as bootstrap files don't contain business logic and are automatically tested by the framework.